### PR TITLE
Refactor user creation to remove fake params suggested by gpt

### DIFF
--- a/unbound-quic-install.sh
+++ b/unbound-quic-install.sh
@@ -23,8 +23,7 @@ sudo cp -r sbin /usr/sbin/ | tee -a run.log
 
 # Generate user for unbound.service
 echo "Generating new user (unbound)"
-sudo groupadd --system unbound | tee -a run.log
-sudo useradd --system --home /var/lib/unbound --shell /usr/sbin/nologin --ingroup unbound unbound | tee -a run.log
+sudo useradd -M --system --shell /usr/sbin/nologin --user-group unbound | tee -a run.log
 
 # Create app directories
 echo "Creating app directories and configuring ownership"


### PR DESCRIPTION
Fixes user generation issue https://github.com/latelatelate/unbound-quic-install/issues/1 from two separate lines into one single command. Removed fake parameter given by chat gpt