### PR TITLE
Fix missing unbound dependency libpython3.11.so.1.0

### DIFF
--- a/unbound-quic-install.sh
+++ b/unbound-quic-install.sh
@@ -14,7 +14,7 @@ REPO_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 rm -f run.log && touch run.log
 
 # Install extra dependencies
-sudo apt install python3 | tee -a run.log
+sudo apt install python3 libpython3-dev | tee -a run.log
 
 # Unzip unbound.tar and move to sbin
 echo "Extracting Unbound"


### PR DESCRIPTION
Missing libpython3.11.so.1.0 dependency for unbound causes failure to start via `systemctl`. Installing `libpython3.11.so.1.0` via `apt` fixes the issue