### PR TITLE
Defer service start until ssl certs installed

### DIFF
--- a/config/unbound.conf
+++ b/config/unbound.conf
@@ -29,8 +29,8 @@ server:
     # enabled in /etc/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf
     auto-trust-anchor-file: "/var/lib/unbound/root.key"
 
-    # enable DOH
-    # use nfs to mount from proxmox host /srv/shared-certs
+    # SSL Cert location required for encrypted DNS queries (DoQ, DoH, DoT)
+    # Queries will return SERVFAIL without valid certs enabled 
     tls-service-key: "/var/lib/unbound/certs/privkey.pem"
     tls-service-pem: "/var/lib/unbound/certs/fullchain.pem"
 
@@ -148,7 +148,11 @@ server:
     msg-cache-size: 128m
     rrset-cache-size: 256m
 
-    # One thread should be sufficient, can be increased on beefy machines. In reality for most users running on small networks or on a single machine, it should be unnecessary to seek performance en>    num-threads: 2
+    # One thread should be sufficient, can be increased on beefy machines. 
+    # In reality for most users running on small networks or on a single machine, 
+    # it should be unnecessary to seek performance enhancement by increasing
+    # num-threads above 1
+    num-threads: 2
 
     # Enable more outgoing connections
     outgoing-range: 512

--- a/unbound-quic-install.sh
+++ b/unbound-quic-install.sh
@@ -13,6 +13,7 @@ REPO_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 UNBOUND_PATH=/etc/unbound
 LIB_PATH=/var/lib/unbound
 LOG_PATH=/var/log/unbound
+CERT_PATH="$LIB_PATH/certs"
 
 rm -f run.log && touch run.log
 
@@ -31,7 +32,7 @@ sudo useradd -M --system --shell /usr/sbin/nologin --user-group unbound | tee -a
 
 # Create app directories
 echo "Creating app directories and configuring ownership"
-sudo mkdir -p "$LIB_PATH/certs" $LOG_PATH $UNBOUND_PATH | tee -a run.log
+sudo mkdir -p $CERT_PATH $LOG_PATH $UNBOUND_PATH | tee -a run.log
 sudo cp "$REPO_PATH/config/unbound.conf" "$UNBOUND_PATH/unbound.conf"
 
 # Generate root hints
@@ -80,6 +81,10 @@ sudo sysctl -p
 
 # Enable unbound
 systemctl enable unbound | tee -a run.log
-systemctl restart unbound | tee -a run.log
-systemctl status unbound | tee -a run.log
-echo "Unbound installed."
+
+printf "\n"
+echo -e "\e[31mWARNING:\e[0m Valid SSL certs required!"
+echo -e "\e[31mWARNING:\e[0m \e[32mprivkey.pem\e[0m and \e[32mfullchain.pem\e[0m must be placed in \e[32m$CERT_PATH\e[0m."
+echo -e "\e[31mWARNING:\e[0m Unbound will fail to start without a valid SSL certificate"
+printf "\n"
+echo "Unbound installed successfully!"


### PR DESCRIPTION
Since unbound compiled with https support won't run without valid ssl certs, defer start of unbound service until user has a chance to generate their own certs.

Perhaps in the future we could automate this into the install script, but I think separate ssl generation logic is for the best